### PR TITLE
Fix cbd

### DIFF
--- a/README.org
+++ b/README.org
@@ -247,14 +247,14 @@ of keymaps, and to facilitate installing and visualizing these keymaps.
    Provides 3-letter aliases to frequently used functions and macros to
    make ~defbuttons~ forms more concise. Within a ~buttons-macrolet~ form, these
    are default aliases:
-   | *shortcut* | *function/macro*                                 |
-   | but        | buttons-make                                     |
-   | cmd        | buttons-defcmd                                   |
-   | ins        | buttons-template-insert                          |
-   | nli        | newline-and-indent                               |
-   | cbd        | (anonymous macro to insert a c-style code block) |
-   | rec        | recursive-edit                                   |
-   | idt        | indent-for-tab-command                           |
+   | *shortcut* | *function/macro*                  |
+   | but        | buttons-make                      |
+   | cmd        | buttons-defcmd                    |
+   | ins        | buttons-template-insert           |
+   | nli        | newline-and-indent                |
+   | cbd        | buttons-insert-c-style-code-block |
+   | rec        | recursive-edit                    |
+   | idt        | indent-for-tab-command            |
 * Additional links
   - [[file:doc/motivation.org][Motivation and Benefits]]
   - [[./doc/buttons/index.html][Auto-generated function/macro index]]

--- a/buttons.el
+++ b/buttons.el
@@ -420,6 +420,16 @@ It should be bound at compile-time via ‘let-when'")
   (message "aborting buttons command...")
   (throw 'buttons-abort nil))
 
+(defun buttons-insert-c-style-code-block ()
+  "Insert a c-style code block with curly braces."
+  (interactive)
+  (insert " {")
+  (newline-and-indent)
+  (recursive-edit)
+  (newline)
+  (insert "}")
+  (indent-for-tab-command))
+
 (defmacro buttons-macrolet (more-macrolet-defs &rest body)
   "Make 3-letter aliases of useful button-related forms available in BODY.
 
@@ -430,12 +440,7 @@ It should be bound at compile-time via ‘let-when'")
         (nli () `(newline-and-indent))
         (ins (&rest text) `(buttons-template-insert ,@text))
         (cmd (&rest rest) `(buttons-defcmd ,@rest))
-        (cbd ()
-             ;; insert a code block with curly braces
-             `(progn (insert " {")
-                     (nli)
-                     (rec)
-                     (insert "}")))
+        (cbd () `(buttons-insert-c-style-code-block))
         (rec () `(recursive-edit))
         (idt () `(indent-for-tab-command))
         ,@more-macrolet-defs)

--- a/buttons.el
+++ b/buttons.el
@@ -434,6 +434,7 @@ It should be bound at compile-time via ‘let-when'")
              ;; insert a code block with curly braces
              `(progn (insert " {")
                      (nli)
+                     (rec)
                      (insert "}")))
         (rec () `(recursive-edit))
         (idt () `(indent-for-tab-command))

--- a/test/buttons-tests.el
+++ b/test/buttons-tests.el
@@ -57,7 +57,7 @@
      ((insert "buttons-test-fn-1")
       (insert "arg1")
       (insert "(1+ arg1)"))
-     (funcall (check (lookup-key emacs-lisp-mode-map (kbd "s-d s-f"))))
+     (press-button emacs-lisp-mode-map (kbd "s-d s-f"))
      (should (equal (read (buffer-string))
                     '(defun buttons-test-fn-1 (arg1) (1+ arg1))))
      (eval-buffer)
@@ -67,12 +67,12 @@
     (lisp-mode)
     (with-mock-recedit
      ((insert "my-var"))
-     (funcall (check (lookup-key lisp-mode-map (kbd "s-d s-p"))))
+     (press-button lisp-mode-map (kbd "s-d s-p"))
      (should (equal (read (buffer-string))
                     '(defparameter my-var))))))
 
 (ert-deftest test-visualization-keybinding ()
-  (funcall (check (lookup-key emacs-lisp-mode-map (kbd "s-?")))))
+  (press-button emacs-lisp-mode-map (kbd "s-?")))
 
 (defun press-button (keymap key)
   (funcall (check (lookup-key keymap key))))

--- a/test/buttons-tests.el
+++ b/test/buttons-tests.el
@@ -73,3 +73,31 @@
 
 (ert-deftest test-visualization-keybinding ()
   (funcall (check (lookup-key emacs-lisp-mode-map (kbd "s-?")))))
+
+(defun press-button (keymap key)
+  (funcall (check (lookup-key keymap key))))
+
+(ert-deftest test-cbd ()
+  (let-when-compile
+      ((buttons-make-key-mapper #'buttons-modifier-add-super))
+    (buttons-macrolet
+     nil
+     (defbuttons test-cbd-buttons nil
+       (c++-mode-map)
+       (but
+        ("t" (cmd (ins "true")))
+        ("g" (cmd (ins "false")))
+        ("z" (cmd (ins "if ({}){(cbd)}")))
+        ("r" (cmd (ins "return {};")))))))
+
+  (with-temp-buffer
+    (c++-mode)
+    (with-mock-recedit
+     ((press-button test-cbd-buttons (kbd "s-t"))
+      (with-mock-recedit
+       ((press-button test-cbd-buttons (kbd "s-g")))
+       (press-button test-cbd-buttons (kbd "s-r"))))
+     (press-button test-cbd-buttons (kbd "s-z")))
+    (message "(buffer-string):\n%s" (buffer-string))
+    (should (string-match "if (true) +{\n +return false;\n *}"
+                          (buffer-string)))))

--- a/test/buttons-tests.el
+++ b/test/buttons-tests.el
@@ -35,14 +35,14 @@
           ("d"
            (but
             ("f" (cmd (ins "(defun {} ({}){(nli)}{})")))))))
-   (defbuttons test-buttons-common-lisp test-buttons-emacs-lisp
-     lisp-mode-map;; ancestor
+   (defbuttons test-buttons-common-lisp
+     test-buttons-emacs-lisp
+     lisp-mode-map
      (but ("d"
            (but ("p"
                  (cmd (ins "(defparameter {})")))))))))
 
 (ert-deftest test-buttons ()
-
   (check (lookup-key emacs-lisp-mode-map (kbd "s-3")))
   (check (lookup-key emacs-lisp-mode-map (kbd "s-d s-f")))
   (check (lookup-key lisp-mode-map (kbd "s-3")))


### PR DESCRIPTION
- fix missing (recursive-edit) in `cbd` macro
- add related test
- move cdb back to a function to support adapting to various indentation styles