### PR TITLE
Doc nits

### DIFF
--- a/README.org
+++ b/README.org
@@ -109,6 +109,8 @@ of keymaps, and to facilitate installing and visualizing these keymaps.
 * Sample visualization
   [[./doc/img/sample-visualization.png]]
 * Installation
+  - ~M-x package-refresh-contents~ and ~M-x package-install RET buttons~
+  - Alternatively
   Place ~buttons.el~ somewhere in the load-path and require the feature:
 
   #+BEGIN_SRC emacs-lisp

--- a/README.org
+++ b/README.org
@@ -117,16 +117,16 @@ of keymaps, and to facilitate installing and visualizing these keymaps.
   #+END_SRC
 
 * Overview
-** ~defbuttons(KEYMAP-VAR ANCESTOR LOAD-AFTER-KEYMAPS KEYMAP)~
+** ~defbuttons(KEYMAP-VAR ANCESTOR TARGET-KEYMAPS KEYMAP)~
    defvar-like wrapper that defines keymap ~KEYMAP~ as ~KEYMAP-VAR~.
 
-   - ~ANCESTOR~ is a keymap used as a starting point from which to inherit common bindings.
-   - ~LOAD-AFTER-KEYMAPS~ specifies a list of keymap symbols onto which to install ~KEYMAP-VAR~
+   - ~ANCESTOR~ is a keymap used as a starting point on top of which to add new key bindings.
+   - ~TARGET-KEYMAPS~ specifies a list of keymap symbols onto which to install ~KEYMAP-VAR~
       whenever those symbols become bound in emacs after a file load.
 
    - How inheritance works
      - Placing ~KEYMAP~ on top of ~ANCESTOR~, as well as placing the newly-defined
-       ~KEYMAP-VAR~ on top of each keymap in ~LOAD-AFTER-KEYMAPS~ as they become available,
+       ~KEYMAP-VAR~ on top of each keymap in ~TARGET-KEYMAPS~ as they become available,
        is done by recursive merging of keymaps via the internal function
        ~buttons-define-keymap-onto-keymap~, which differs from ~(set-keymap-parent ...)~
        in that nested keymaps (or bindings for prefix keys) are merged instead of
@@ -204,11 +204,9 @@ of keymaps, and to facilitate installing and visualizing these keymaps.
 
     ;; expands to:
 
-    (let
-        (rec-capture-0-86054)
+    (let (rec-capture-0-86054)
       (insert "for ( int ")
-      (setf rec-capture-0-86054
-            (buttons-record-template-var))
+      (setf rec-capture-0-86054 (buttons-record-template-var))
       (insert " = 0; ")
       (insert rec-capture-0-86054)
       (insert " < ")
@@ -216,11 +214,8 @@ of keymaps, and to facilitate installing and visualizing these keymaps.
       (insert "; ")
       (insert rec-capture-0-86054)
       (insert "++ )")
-      (let*
-          ((expr-val-86055
-            (newline-and-indent)))
-        (when
-            (stringp expr-val-86055)
+      (let* ((expr-val-86055 (newline-and-indent)))
+        (when (stringp expr-val-86055)
           (insert expr-val-86055))))
     #+END_SRC
   - It is possible to change the directive regexp from matching ~{...}~
@@ -229,11 +224,25 @@ of keymaps, and to facilitate installing and visualizing these keymaps.
      through ~let-when-compile~:
 
      #+BEGIN_SRC emacs-lisp
-     (let-when-compile
-                ((buttons-template-insert-directive-regexp "<\\(.*?\\)>"))
+     (let-when-compile ((buttons-template-insert-directive-regexp "<\\(.*?\\)>"))
                 ;; insert a bash variable surrounded by double quotes
               (buttons-template-insert "\"${<>}\""))
      #+END_SRC
+    - A simpler way to achieve the same result is to break up the directive
+      across multiple strings, since a valid directive must be fully contained
+      within one string:
+
+      #+BEGIN_SRC emacs-lisp
+      (macroexpand '(buttons-template-insert "\"${" "{}" "}\"")
+
+      =>
+
+      (let nil
+         (insert "\"${")
+         (buttons-record-template-var)
+         (insert "}\"")))
+      #+END_SRC
+
 
 ** ~buttons-defcmd (&rest BODY)~ (aka *cmd*)
    A convenience macro for defining an auto-documented, auto-named 0-ary

--- a/buttons.el
+++ b/buttons.el
@@ -175,16 +175,16 @@ It should be bound at compile-time via ‘let-when'")
                       (symbol-name (symbol-at-point)))
                     'variable-name-history)))
 
-(defun buttons-display (&optional keymap hide-command-names-p hide-command-use-count-p)
+(defun buttons-display (&optional keymap hide-command-names hide-command-use-count)
   "Visualize a keymap KEYMAP in a help buffer.
 
    Unlike the standard keymap bindings help, nested keymaps
    are visualized recursively.  This is suitable for visualizing
    BUTTONS-MAKE-defined nested keymaps.
 
-   If HIDE-COMMAND-NAMES-P is non-nil, command names are not displayed.
+   If HIDE-COMMAND-NAMES is non-nil, command names are not displayed.
 
-   If HIDE-COMMAND-USE-COUNT-P is non-nil, no attempt is made to display
+   If HIDE-COMMAND-USE-COUNT is non-nil, no attempt is made to display
    recorded command use-counts.
 
    When called with a nil keymap, or interactively with a prefix argument,
@@ -205,7 +205,7 @@ It should be bound at compile-time via ‘let-when'")
                 (remove-newlines (string)
                                  (replace-regexp-in-string "\n" "\\\\n" string))
                 (print-command (binding)
-                               (unless hide-command-names-p
+                               (unless hide-command-names
                                  (if (and (commandp binding);;not a keymap
                                           (symbolp binding);;not an anonymous lambda
                                           binding)
@@ -216,7 +216,7 @@ It should be bound at compile-time via ‘let-when'")
                                       'help-args (list binding)
                                       'button '(t))
                                    (princ (remove-newlines (prin1-to-string binding)))))
-                               (unless hide-command-use-count-p
+                               (unless hide-command-use-count
                                  (let ((use-count-width
                                         (and (symbolp binding)
                                              (< 0 (or (get binding 'use-count) 0))

--- a/buttons.el
+++ b/buttons.el
@@ -25,7 +25,7 @@
 
 ;;; Commentary:
 
-;; A library and template language to define and visualize hierarchies keymaps.
+;; A library and template language to define and visualize hierarchies of keymaps.
 
 ;;; Code:
 
@@ -87,13 +87,13 @@ It should be bound at compile-time via ‘let-when'")
                   key-spec)))
     (t key-spec)))
 
-(defmacro defbuttons (kmap-sym ancestor-kmap load-after-keymap-syms keymap)
+(defmacro defbuttons (kmap-sym ancestor-kmap target-keymap-syms keymap)
   "Define a keymap KMAP-SYM.
 
    ANCESTOR-KMAP, if non-nil,is merged recursively onto
    KMAP-SYM via BUTTONS-DEFINE-KEYMAP-ONTO-KEYMAP.
 
-   LOAD-AFTER-KEYMAP-SYMS is a list of keymap symbols, bound or unbound,
+   TARGET-KEYMAP-SYMS is a list of keymap symbols, bound or unbound,
    onto which to define KMAP-SYM via BUTTONS-AFTER-SYMBOL-LOADED-FUNCTION-ALIST.
 
    KEYMAP is the keymap, for example, one defined via BUTTONS-MAKE."
@@ -103,10 +103,10 @@ It should be bound at compile-time via ‘let-when'")
        (setf ,kmap-sym ,keymap)
        ,@(when ancestor-kmap
            `((buttons-define-keymap-onto-keymap ,ancestor-kmap ,kmap-sym ',kmap-sym t)))
-       ,@(cl-loop for orig in (if (and load-after-keymap-syms
-                                       (atom load-after-keymap-syms))
-                                  (list load-after-keymap-syms)
-                                load-after-keymap-syms)
+       ,@(cl-loop for orig in (if (and target-keymap-syms
+                                       (atom target-keymap-syms))
+                                  (list target-keymap-syms)
+                                target-keymap-syms)
                   as form = `(buttons-define-keymap-onto-keymap ,kmap-sym ,orig)
                   append
                   (if (boundp orig)
@@ -412,7 +412,7 @@ It should be bound at compile-time via ‘let-when'")
    as the USE-COUNT property of the function symbol.
    This may be useful for analysis and for making
    decisions about which bindings' key-sequence
-   lengths are worth shortening."
+   lengths are worth reducing."
   (cl-loop for form in body
            with forms = nil
            with doc = nil


### PR DESCRIPTION
- add melpa installation instructions
- rename `LOAD-AFTER-KEYMAPS` to more intuitive `TARGET-KEYMAPS`