### PR TITLE
Fix warning text

### DIFF
--- a/buttons.el
+++ b/buttons.el
@@ -133,10 +133,12 @@ It should be bound at compile-time via ‘let-when'")
                             (merge cmd existing (cons (key-description keyvec) path)))
                            ((or (not no-overwrite-p) (not existing))
                             (when (and existing (keymapp existing))
-                              (warn "%s overwrites nested keymap with plain command on %s %s"
-                                    (if from-sym (symbol-name from-sym) "child")
-                                    (key-description keyvec)
-                                    (or (reverse path) "")))
+                              (warn
+                               "non-keymap `%s' overwrites keymap in `%s' on %s %s "
+                               cmd
+                               (if from-sym (symbol-name from-sym) "child")
+                               (key-description keyvec)
+                               (or (reverse path) "")))
                             (define-key to-map keyvec cmd)))))
                       from-map)))
     (merge from-map to-map)))

--- a/buttons.el
+++ b/buttons.el
@@ -134,7 +134,7 @@ It should be bound at compile-time via ‘let-when'")
                            ((or (not no-overwrite-p) (not existing))
                             (when (and existing (keymapp existing))
                               (warn "%s overwrites nested keymap with plain command on %s %s"
-                                    (or (symbol-name from-sym) "child")
+                                    (if from-sym (symbol-name from-sym) "child")
                                     (key-description keyvec)
                                     (or (reverse path) "")))
                             (define-key to-map keyvec cmd)))))

--- a/buttons.el
+++ b/buttons.el
@@ -107,7 +107,7 @@ It should be bound at compile-time via ‘let-when'")
                                        (atom target-keymap-syms))
                                   (list target-keymap-syms)
                                 target-keymap-syms)
-                  as form = `(buttons-define-keymap-onto-keymap ,kmap-sym ,orig)
+                  as form = `(buttons-define-keymap-onto-keymap ,kmap-sym ,orig ',orig)
                   append
                   (if (boundp orig)
                       `(,form)

--- a/test/buttons-tests.el
+++ b/test/buttons-tests.el
@@ -46,11 +46,13 @@
                  (cmd (ins "(defparameter {})")))))))))
 
 (ert-deftest test-buttons ()
-  (check (lookup-key emacs-lisp-mode-map (kbd "s-3")))
-  (check (lookup-key emacs-lisp-mode-map (kbd "s-d s-f")))
-  (check (lookup-key lisp-mode-map (kbd "s-3")))
-  (check (lookup-key lisp-mode-map (kbd "s-d s-f")))
+  (dolist (kmap (list emacs-lisp-mode-map lisp-mode-map))
+    (dolist (key (list (kbd "s-3") (kbd "s-d s-f")))
+      ;; both keymaps have the ancestor's bindings
+      (check (lookup-key kmap key))))
+
   (check (lookup-key lisp-mode-map (kbd "s-d s-p")))
+  ;; no defparameter in emacs-lisp
   (check (not (lookup-key emacs-lisp-mode-map (kbd "s-d s-p"))))
 
   (with-temp-buffer

--- a/test/buttons-tests.el
+++ b/test/buttons-tests.el
@@ -155,14 +155,13 @@
                      " }")
              (buffer-string)))))
 
-(defvar buttons--test-overriding-keymap-warning)
 
 (ert-deftest test-overriding-keymap-warning ()
   (buttons-macrolet
    ()
-   (setq buttons--test-overriding-keymap-warning
-         (but ([f1] (make-sparse-keymap))))
-   (lexical-let (warnings)
+   (let (warnings
+         (buttons--test-overriding-keymap-warning (but ([f1] (make-sparse-keymap)))))
+     (defvar buttons--test-overriding-keymap-warning)
      (cl-letf (((symbol-function 'warn)
                 (lambda (fmt &rest args)
                   (push (apply #'format fmt args) warnings))))

--- a/test/buttons-tests.el
+++ b/test/buttons-tests.el
@@ -63,18 +63,18 @@
      ((insert "buttons-test-fn-1")
       (insert "arg1")
       (insert "(1+ arg1)")))
-     (should (equal (read (buffer-string))
-                    '(defun buttons-test-fn-1 (arg1) (1+ arg1))))
-     (eval-buffer)
-     (should (= (buttons-test-fn-1 2) 3)))
+    (should (equal (read (buffer-string))
+                   '(defun buttons-test-fn-1 (arg1) (1+ arg1))))
+    (eval-buffer)
+    (should (= (buttons-test-fn-1 2) 3)))
 
   (with-temp-buffer
     (lisp-mode)
     (with-mock-recedit
      (press-button lisp-mode-map (kbd "s-d s-p"))
      ((insert "my-var")))
-     (should (equal (read (buffer-string))
-                    '(defparameter my-var)))))
+    (should (equal (read (buffer-string))
+                   '(defparameter my-var)))))
 
 (ert-deftest test-visualization-keybinding ()
   (press-button emacs-lisp-mode-map (kbd "s-?")))

--- a/test/buttons-tests.el
+++ b/test/buttons-tests.el
@@ -16,7 +16,10 @@
                                collect `(,i ,form))
                          `((t (error "Recursive-edit called too many times")))))
                     (incf ,count-sym))))
-         ,body))))
+         ,body
+         (unless (eq ,(length recedit-forms) ,count-sym)
+           (error "Recursive-edit called %s times, not %s"
+                  ,count-sym ,(length recedit-forms)))))))
 
 (defmacro check (form)
   "Ensure FORM is non-nil."

--- a/test/buttons-tests.el
+++ b/test/buttons-tests.el
@@ -155,20 +155,20 @@
                      " }")
              (buffer-string)))))
 
-
 (ert-deftest test-overriding-keymap-warning ()
   (buttons-macrolet
    ()
    (let (warnings
-         (buttons--test-overriding-keymap-warning (but ([f1] (make-sparse-keymap)))))
-     (defvar buttons--test-overriding-keymap-warning)
+         (buttons-tests--target-keymap (but ([f1] (make-sparse-keymap)))))
+     (defvar buttons-tests--target-keymap)
      (cl-letf (((symbol-function 'warn)
                 (lambda (fmt &rest args)
                   (push (apply #'format fmt args) warnings))))
-       (eval '(defbuttons child-overriding-to-keymap
+       (eval '(defbuttons overriding-keymap
                 nil
-                buttons--test-overriding-keymap-warning
+                buttons-tests--target-keymap
                 (buttons-make ([f1] 'next-line))))
        (should (eql 1 (length warnings)))
        ;; expect sym name in warning string
-       (should (string-match-p "buttons--test-overriding-keymap-warning" (car warnings)))))))
+       (should (string-match-p "buttons-tests--target-keymap"
+                               (car warnings)))))))

--- a/test/buttons-tests.el
+++ b/test/buttons-tests.el
@@ -154,3 +154,22 @@
                      "  }\n"
                      " }")
              (buffer-string)))))
+
+(defvar buttons--test-overriding-keymap-warning)
+
+(ert-deftest test-overriding-keymap-warning ()
+  (buttons-macrolet
+   ()
+   (setq buttons--test-overriding-keymap-warning
+         (but ([f1] (make-sparse-keymap))))
+   (lexical-let (warnings)
+     (cl-letf (((symbol-function 'warn)
+                (lambda (fmt &rest args)
+                  (push (apply #'format fmt args) warnings))))
+       (eval '(defbuttons child-overriding-to-keymap
+                nil
+                buttons--test-overriding-keymap-warning
+                (buttons-make ([f1] 'next-line))))
+       (should (eql 1 (length warnings)))
+       ;; expect sym name in warning string
+       (should (string-match-p "buttons--test-overriding-keymap-warning" (car warnings)))))))


### PR DESCRIPTION
Fix not displaying keymap name in warning text