### PR TITLE
Fix anon minor mode map

### DIFF
--- a/buttons.el
+++ b/buttons.el
@@ -97,6 +97,7 @@ It should be bound at compile-time via ‘let-when'")
    onto which to define KMAP-SYM via BUTTONS-AFTER-SYMBOL-LOADED-FUNCTION-ALIST.
 
    KEYMAP is the keymap, for example, one defined via BUTTONS-MAKE."
+  (declare (indent 3))
   (let* ((sym-name (symbol-name kmap-sym)))
     `(progn
        (defvar ,kmap-sym nil ,(format "%s buttons map" sym-name))

--- a/buttons.el
+++ b/buttons.el
@@ -242,14 +242,18 @@ It should be bound at compile-time via ‘let-when'")
                                               (print-command binding)
                                               (princ "\n")))
                                           keymap))
-                (find-keymap-symbol (keymap)
-                                    (cl-block nil
+                (find-keymap-descriptor (keymap)
+                                    (or
+                                     (cl-block nil
                                       (mapatoms (lambda (sym)
                                                   (when (and
                                                          (not (eq sym 'keymap))
                                                          (boundp sym)
                                                          (eq (symbol-value sym) keymap))
-                                                    (cl-return sym))))))
+                                                    (cl-return sym)))))
+                                     (cl-loop for (minor-mode-sym . kmap) in minor-mode-map-alist
+                                              thereis (when (equal kmap keymap)
+                                                        (format "%s (minor-mode-map-alist)" minor-mode-sym)))))
                 (max-event-length (keymap)
                                   (let ((max 0))
                                     (map-keymap
@@ -264,7 +268,7 @@ It should be bound at compile-time via ‘let-when'")
           (cond
            ((null keymap) (list "(current-active-maps)" (current-active-maps)))
            ((symbolp keymap) (list (symbol-name keymap) (list (symbol-value keymap))))
-           (t (list (find-keymap-symbol keymap) (list keymap))))
+           (t (list (find-keymap-descriptor keymap) (list keymap))))
         (let ((max-event-length (cl-loop for kmap in kmaps
                                          maximize (max-event-length kmap)))
               (buffer-name (format "*%s help*" (or name "keymap")))
@@ -273,7 +277,7 @@ It should be bound at compile-time via ‘let-when'")
             (with-current-buffer
                 buffer-name
               (dolist (kmap kmaps)
-                (princ (or (find-keymap-symbol kmap) "(anonymous keymap)"))
+                (princ (or (find-keymap-descriptor kmap) "(anonymous keymap)"))
                 (add-text-properties (line-beginning-position)
                                      (line-end-position)
                                      '(face bold))

--- a/buttons.el
+++ b/buttons.el
@@ -243,17 +243,20 @@ It should be bound at compile-time via ‘let-when'")
                                               (princ "\n")))
                                           keymap))
                 (find-keymap-descriptor (keymap)
-                                    (or
-                                     (cl-block nil
-                                      (mapatoms (lambda (sym)
-                                                  (when (and
-                                                         (not (eq sym 'keymap))
-                                                         (boundp sym)
-                                                         (eq (symbol-value sym) keymap))
-                                                    (cl-return sym)))))
-                                     (cl-loop for (minor-mode-sym . kmap) in minor-mode-map-alist
-                                              thereis (when (equal kmap keymap)
-                                                        (format "%s (minor-mode-map-alist)" minor-mode-sym)))))
+                                        (or
+                                         (cl-block nil
+                                           (mapatoms (lambda (sym)
+                                                       (when (and
+                                                              (not (eq sym 'keymap))
+                                                              (boundp sym)
+                                                              (eq (symbol-value sym) keymap))
+                                                         (cl-return sym)))))
+                                         (cl-loop for (minor-mode-sym . kmap)
+                                                  in minor-mode-map-alist
+                                                  thereis
+                                                  (when (equal kmap keymap)
+                                                    (format "%s (minor-mode-map-alist)"
+                                                            minor-mode-sym)))))
                 (max-event-length (keymap)
                                   (let ((max 0))
                                     (map-keymap


### PR DESCRIPTION
- fix not finding name for keymaps in `minor-mode-map-alist`
- specify `defbuttons` macro indentation