### PR TITLE
return the resulting `to-map` to support use as an expression

### DIFF
--- a/buttons.el
+++ b/buttons.el
@@ -141,7 +141,8 @@ It should be bound at compile-time via ‘let-when'")
                                (key-description keyvec)
                                (or (reverse path) "")))
                             (define-key to-map keyvec cmd)))))
-                      from-map)))
+                      from-map)
+                     to-map))
     (merge from-map to-map)))
 
 (defvar buttons-after-symbol-loaded-function-alist nil


### PR DESCRIPTION
Allow using `(buttons-define-keymap-onto-keymap FROM TO)` as an expression. This makes it easier to extend existing keymaps without modifying them:

    (buttons-define-keymap-onto-keymap EXISTING-MAP (buttons-make ...))